### PR TITLE
Fixed anomaly where sun does not rise or set

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Next, feed the information into the SunriseSunset() method:
         2000, time.January, 1,  // 2000-01-01
     )
 
-The two return values will be the sunrise and sunset times for the location on the given day as time.Time values.
+The two return values will be the sunrise and sunset times for the location on the given day as time.Time values. If sun does not rise or set, both return values will be time.Time{}.

--- a/hourangle.go
+++ b/hourangle.go
@@ -13,5 +13,17 @@ func HourAngle(latitude, declination float64) float64 {
 		numerator      = -0.01449 - math.Sin(latitudeRad)*math.Sin(declinationRad)
 		denominator    = math.Cos(latitudeRad) * math.Cos(declinationRad)
 	)
+
+	// Check for no sunrise/sunset
+	if numerator/denominator > 1 {
+		// Sun never rises
+		return math.MaxFloat64
+	}
+
+	if numerator/denominator < -1 {
+		// Sun never sets
+		return -1 * math.MaxFloat64
+	}
+
 	return math.Acos(numerator/denominator) / Degree
 }

--- a/sunrise.go
+++ b/sunrise.go
@@ -1,11 +1,13 @@
 package sunrise
 
 import (
+	"math"
 	"time"
 )
 
 // SunriseSunset calculates when the sun will rise and when it will set on the
 // given day at the specified location.
+// Returns time.Time{} if there sun does not rise or set
 func SunriseSunset(latitude, longitude float64, year int, month time.Month, day int) (time.Time, time.Time) {
 	var (
 		d                 = MeanSolarNoon(longitude, year, month, day)
@@ -19,5 +21,11 @@ func SunriseSunset(latitude, longitude float64, year int, month time.Month, day 
 		sunrise           = solarTransit - frac
 		sunset            = solarTransit + frac
 	)
+
+	// Check for no sunrise, no sunset
+	if hourAngle == math.MaxFloat64 || hourAngle == -1*math.MaxFloat64 {
+		return time.Time{}, time.Time{}
+	}
+
 	return JulianDayToTime(sunrise), JulianDayToTime(sunset)
 }

--- a/sunrise_test.go
+++ b/sunrise_test.go
@@ -35,6 +35,13 @@ var dataSunriseSunset = []struct {
 		time.Date(2004, time.April, 1, 5, 13, 40, 0, time.UTC),
 		time.Date(2004, time.April, 1, 18, 13, 27, 0, time.UTC),
 	},
+	// 2020-06-15 - Igloolik, Canada
+	{
+		69.3321443, -81.6781126,
+		2020, time.June, 25,
+		time.Time{},
+		time.Time{},
+	},
 }
 
 func TestSunriseSunset(t *testing.T) {


### PR DESCRIPTION
This fixes issue #6  where does not rise or set. In this case, `SunriseSunset` now returns two `time.Time{}` values as indication that such condition has occured.

I've added a test for the condition as described, and it passess alongside with all existing tests.