### PR TITLE
Add TimeOfElevation

### DIFF
--- a/elevation.go
+++ b/elevation.go
@@ -1,0 +1,34 @@
+package sunrise
+
+import (
+	"math"
+	"time"
+)
+
+// TimeOfElevation calculates the times of day when the sun is at a given elevation
+// above the horizon on a given day at the specified location.
+// Returns time.Time{} if there sun does not reach the elevation
+func TimeOfElevation(latitude, longitude, elevation float64, year int, month time.Month, day int) (time.Time, time.Time) {
+	var (
+		d                 = MeanSolarNoon(longitude, year, month, day)
+		solarAnomaly      = SolarMeanAnomaly(d)
+		equationOfCenter  = EquationOfCenter(solarAnomaly)
+		eclipticLongitude = EclipticLongitude(solarAnomaly, equationOfCenter, d)
+		solarTransit      = SolarTransit(d, solarAnomaly, eclipticLongitude)
+		declination       = Declination(eclipticLongitude)
+		// https://solarsena.com/solar-elevation-angle-altitude/
+		numerator        = math.Sin(elevation*Degree) - (math.Sin(latitude*Degree) * math.Sin(declination*Degree))
+		denominator      = math.Cos(latitude*Degree) * math.Cos(declination*Degree)
+		hourAngle        = math.Acos(numerator / denominator)
+		secondsAfterNoon = hourAngle / (2 * math.Pi)
+		morning          = solarTransit - secondsAfterNoon
+		evening          = solarTransit + secondsAfterNoon
+	)
+
+	// Check for cases where the sun never reaches the given elevation.
+	if math.IsNaN(hourAngle) {
+		return time.Time{}, time.Time{}
+	}
+
+	return JulianDayToTime(morning), JulianDayToTime(evening)
+}

--- a/elevation.go
+++ b/elevation.go
@@ -17,12 +17,12 @@ func TimeOfElevation(latitude, longitude, elevation float64, year int, month tim
 		solarTransit      = SolarTransit(d, solarAnomaly, eclipticLongitude)
 		declination       = Declination(eclipticLongitude)
 		// https://solarsena.com/solar-elevation-angle-altitude/
-		numerator        = math.Sin(elevation*Degree) - (math.Sin(latitude*Degree) * math.Sin(declination*Degree))
-		denominator      = math.Cos(latitude*Degree) * math.Cos(declination*Degree)
-		hourAngle        = math.Acos(numerator / denominator)
-		secondsAfterNoon = hourAngle / (2 * math.Pi)
-		morning          = solarTransit - secondsAfterNoon
-		evening          = solarTransit + secondsAfterNoon
+		numerator   = math.Sin(elevation*Degree) - (math.Sin(latitude*Degree) * math.Sin(declination*Degree))
+		denominator = math.Cos(latitude*Degree) * math.Cos(declination*Degree)
+		hourAngle   = math.Acos(numerator / denominator)
+		frac        = hourAngle / (2 * math.Pi)
+		morning     = solarTransit - frac
+		evening     = solarTransit + frac
 	)
 
 	// Check for cases where the sun never reaches the given elevation.
@@ -31,4 +31,24 @@ func TimeOfElevation(latitude, longitude, elevation float64, year int, month tim
 	}
 
 	return JulianDayToTime(morning), JulianDayToTime(evening)
+}
+
+// Elevation calculates the angle of the sun above the horizon at a given moment
+// at the specified location.
+func Elevation(latitude, longitude float64, when time.Time) float64 {
+	var (
+		d                 = MeanSolarNoon(longitude, when.Year(), when.Month(), when.Day())
+		solarAnomaly      = SolarMeanAnomaly(d)
+		equationOfCenter  = EquationOfCenter(solarAnomaly)
+		eclipticLongitude = EclipticLongitude(solarAnomaly, equationOfCenter, d)
+		solarTransit      = SolarTransit(d, solarAnomaly, eclipticLongitude)
+		declination       = Declination(eclipticLongitude)
+		frac              = solarTransit - TimeToJulianDay(when)
+		hourAngle         = 2 * math.Pi * frac
+		// https://solarsena.com/solar-elevation-angle-altitude/
+		firstPart         = math.Sin(latitude*Degree) * math.Sin(declination*Degree)
+		secondPart        = math.Cos(latitude*Degree) * math.Cos(declination*Degree) * math.Cos(hourAngle)
+	)
+
+	return math.Asin(firstPart+secondPart) / Degree
 }

--- a/elevation_test.go
+++ b/elevation_test.go
@@ -1,0 +1,106 @@
+package sunrise
+
+import (
+	"testing"
+	"time"
+)
+
+func abs(x int64) int64 {
+	if x >= 0 {
+		return x
+	}
+	return -x
+}
+
+// Sunrise is defined to be when the Sun is 50 arc minutes below the horizon.
+// This is due to atmospheric refraction and measuring the position of the top
+// rather than the centre of the Sun.
+// https://en.wikipedia.org/wiki/Sunrise#Angle
+var sunriseElevation = -50.0 / 60.0
+
+var dataElevation = []struct {
+	inLatitude  float64
+	inLongitude float64
+	inElevation float64
+	inYear      int
+	inMonth     time.Month
+	inDay       int
+	outFirst    time.Time
+	outSecond   time.Time
+}{
+	// 1970-01-01 - prime meridian
+	{
+		0, 0, sunriseElevation,
+		1970, time.January, 1,
+		time.Date(1970, time.January, 1, 5, 59, 54, 0, time.UTC),
+		time.Date(1970, time.January, 1, 18, 07, 07, 0, time.UTC),
+	},
+	// 2000-01-01 - Toronto (43.65° N, 79.38° W)
+	{
+		43.65, -79.38, sunriseElevation,
+		2000, time.January, 1,
+		time.Date(2000, time.January, 1, 12, 51, 00, 0, time.UTC),
+		time.Date(2000, time.January, 1, 21, 50, 36, 0, time.UTC),
+	},
+	// 2004-04-01 - (52° N, 5° E)
+	{
+		52, 5, sunriseElevation,
+		2004, time.April, 1,
+		time.Date(2004, time.April, 1, 5, 13, 40, 0, time.UTC),
+		time.Date(2004, time.April, 1, 18, 13, 27, 0, time.UTC),
+	},
+	// 2020-06-15 - Igloolik, Canada
+	{
+		69.3321443, -81.6781126, sunriseElevation,
+		2020, time.June, 25,
+		time.Time{},
+		time.Time{},
+	},
+	// 2022-08-27 - London, end of Shabbat
+	{
+		51.5072, -0.1276, -8.5,
+		2022, time.August, 27,
+		time.Date(2022, time.August, 27, 4, 11, 31, 0, time.UTC),
+		time.Date(2022, time.August, 27, 19, 53, 6, 0, time.UTC),
+	},
+	// 2022-06-21 - London, highest point around noon
+	{
+		51.5072, -0.1276, 61.93,
+		2022, time.June, 21,
+		time.Date(2022, time.June, 21, 12, 0, 12, 0, time.UTC),
+		time.Date(2022, time.June, 21, 12, 4, 16, 0, time.UTC),
+	},
+	// 2022-06-21 - London, too high, never reached
+	{
+		51.5072, -0.1276, 61.94,
+		2022, time.June, 21,
+		time.Time{},
+		time.Time{},
+	},
+	// 2022-06-21 - London, too low, never reached
+	{
+		51.5072, -0.1276, -16,
+		2022, time.June, 21,
+		time.Time{},
+		time.Time{},
+	},
+	// 2022-11-26 - New York City, end of Shabbat
+	{
+		40.7128, -74.006, -8.5,
+		2022, time.November, 26,
+		time.Date(2022, time.November, 26, 11, 11, 19, 0, time.UTC),
+		time.Date(2022, time.November, 26, 22, 15, 46, 0, time.UTC),
+	},
+}
+
+func TestTimeOfElevation(t *testing.T) {
+	for _, tt := range dataElevation {
+		vFirst, vSecond := TimeOfElevation(tt.inLatitude, tt.inLongitude, tt.inElevation, tt.inYear, tt.inMonth, tt.inDay)
+		if abs(vFirst.Unix()-tt.outFirst.Unix()) > 2 {
+			t.Fatalf("%s != %s", vFirst.String(), tt.outFirst.String())
+		}
+		if abs(vSecond.Unix()-tt.outSecond.Unix()) > 2 {
+			t.Fatalf("%s != %s", vSecond.String(), tt.outSecond.String())
+		}
+	}
+}

--- a/elevation_test.go
+++ b/elevation_test.go
@@ -1,6 +1,7 @@
 package sunrise
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -101,6 +102,23 @@ func TestTimeOfElevation(t *testing.T) {
 		}
 		if abs(vSecond.Unix()-tt.outSecond.Unix()) > 2 {
 			t.Fatalf("%s != %s", vSecond.String(), tt.outSecond.String())
+		}
+	}
+}
+
+func TestElevation(t *testing.T) {
+	for _, tt := range dataElevation {
+		if (tt.outFirst == time.Time{}) || (tt.outSecond == time.Time{}) {
+			continue // Not reversible from output
+		}
+
+		vFirst := Elevation(tt.inLatitude, tt.inLongitude, tt.outFirst)
+		if math.Abs(vFirst-tt.inElevation) > 2 {
+			t.Fatalf("%f != %f", vFirst, tt.inElevation)
+		}
+		vSecond := Elevation(tt.inLatitude, tt.inLongitude, tt.outSecond)
+		if math.Abs(vSecond-tt.inElevation) > 2 {
+			t.Fatalf("%f != %f", vSecond, tt.inElevation)
 		}
 	}
 }


### PR DESCRIPTION
Computes the two times of day when the sun is at a given angle above (or below) the horizon.

It's not strictly sunrise or sunset, but the maths is closely related and it's really handy to use your functions.

I realise you're not actively working on this library, but I have a use case in a project that depends on it (https://github.com/tidbyt/pixlet).

Someone wants to display the start and end time of Shabbat. The end time is when the sun is 8.5 degrees below the horizon. This function makes it easy to compute that.

The alternative would be to add this logic just to pixlet. It can use all of the same functions as they're exported by your library. But it seems general and related enough to belong in the library where others could use them.

Included tests to ensure this gives consistent answers to SunriseSunset.